### PR TITLE
Process escape codes in numbered stdin buffers

### DIFF
--- a/rc/ansi.kak
+++ b/rc/ansi.kak
@@ -67,7 +67,7 @@ define-command \
     set-option buffer ansi_color_ranges %val{timestamp}
 }
 
-hook -group ansi global BufCreate '\*stdin\*' %{
+hook -group ansi global BufCreate '\*stdin(?:-\d+)?\*' %{
     hook -group ansi buffer BufReadFifo .* %{
         evaluate-commands -draft %sh{
             printf "select %s\n" "$kak_hook_param"


### PR DESCRIPTION
As produced by piping to "kak -c session", since
https://github.com/mawww/kakoune/commit/60154300f9