### PR TITLE
Minor tweaks

### DIFF
--- a/rc/ansi.kak
+++ b/rc/ansi.kak
@@ -4,7 +4,8 @@ declare-option -hidden str ansi_filter %sh{
     filterdir="$(dirname $kak_source)/.."
     filter="${filterdir}/kak-ansi-filter"
     if ! [ -x "${filter}" ]; then
-        ( cd "$filterdir" && ${CC-cc} -o kak-ansi-filter kak-ansi-filter.c )
+        echo "kak-ansi: Compiling kak-ansi-filter.c" >&2
+        ( set -x; cd "$filterdir" && ${CC-cc} -o kak-ansi-filter kak-ansi-filter.c )
         if ! [ -x "${filter}" ]; then
             filter=$(command -v cat)
         fi

--- a/rc/ansi.kak
+++ b/rc/ansi.kak
@@ -4,7 +4,7 @@ declare-option -hidden str ansi_filter %sh{
     filterdir="$(dirname $kak_source)/.."
     filter="${filterdir}/kak-ansi-filter"
     if ! [ -x "${filter}" ]; then
-        ( cd "$filterdir" && ${CC-c99} -o kak-ansi-filter kak-ansi-filter.c )
+        ( cd "$filterdir" && ${CC-cc} -o kak-ansi-filter kak-ansi-filter.c )
         if ! [ -x "${filter}" ]; then
             filter=$(command -v cat)
         fi


### PR DESCRIPTION
Some minor tweaks:

- The `Makefile` compiles using `cc` while `rc/ansi.kak` compiles using `c99`. Change to `cc` in `rc/ansi.kak` to be consistent.

- The auto compilation of `kak-ansi-filter.c` is useful but a bit surprising. It might be a good idea to have some minimal information displayed in `*debug*` to show what happened.


