### PR TITLE
Do a initial render in ansi-enable and avoid duplicated hooks

### DIFF
--- a/rc/ansi.kak
+++ b/rc/ansi.kak
@@ -58,6 +58,8 @@ define-command \
     -params 0 \
     ansi-enable %{
     try ansi-setup-buffer
+    ansi-render
+    remove-hooks buffer ansi
     hook -group ansi buffer BufReadFifo .* %{
         evaluate-commands -draft %{
             select "%val{hook_param}"


### PR DESCRIPTION
Remove the existing ansi hooks in ansi-enable so that the following config: `hook global BufOpenFifo .* ansi-enable` does not accumulate the rendering hooks every time the same buffer is re-used for a fifo which leads to progressively slower and slower performance.