### PR TITLE
Remove temporary files when done

### DIFF
--- a/rc/ansi.kak
+++ b/rc/ansi.kak
@@ -27,6 +27,10 @@ define-command -hidden ansi-setup-buffer %{
     add-highlighter buffer/ansi ranges ansi_color_ranges
     set-option buffer ansi_color_ranges %val{timestamp}
     set-option buffer ansi_command_file %sh{mktemp}
+    hook -always -once buffer BufClose .* %{
+	    nop %sh{rm ${kak_opt_ansi_command_file}}
+	    set-option buffer ansi_command_file /dev/null
+    }
 }
 
 define-command -hidden ansi-render-selection-impl %{


### PR DESCRIPTION
I noticed that we leak files like /tmp/tmp* which is
%opt{ansi_command_file}.  Remove it at least after the buffer is closed.

The option is buffer scoped but it could be global.  Probably we
should just use kak_command_fifo instead of our own temporary file but
apparently some people use Kakoune from 2020 shipped by their Ubuntu.
