### PR TITLE
Don't clobber shell command history register

### DIFF
--- a/rc/ansi.kak
+++ b/rc/ansi.kak
@@ -30,10 +30,12 @@ define-command -hidden ansi-setup-buffer %{
 }
 
 define-command -hidden ansi-render-selection-impl %{
-    set-register '|' "%opt{ansi_filter} -range %val{selection_desc} 2>%opt{ansi_command_file}"
-    execute-keys "|<ret>"
-    update-option buffer ansi_color_ranges
-    source "%opt{ansi_command_file}"
+    evaluate-commands -save-regs | %{
+        set-register '|' "%opt{ansi_filter} -range %val{selection_desc} 2>%opt{ansi_command_file}"
+        execute-keys "|<ret>"
+        update-option buffer ansi_color_ranges
+        source "%opt{ansi_command_file}"
+    }
 }
 
 define-command \


### PR DESCRIPTION
Commit f0cbe18 (Extract highlighter/option setup in a command,
2023-11-01) added to the '|' register, which resulted in commands
like the following being added to the history. Fix that.

	.../kak-ansi/rc/../kak-ansi-filter -range 344.890,473.374 2>/tmp/tmp.tzCogaMuyw
