### PR TITLE
Add support for BEL terminated OSC8 sequences

### DIFF
--- a/kak-ansi-filter.c
+++ b/kak-ansi-filter.c
@@ -324,7 +324,7 @@ wchar_t handle_escape_char(wchar_t ch)
         {
         case L']':
             /* OSC escapes, used by shell integration */
-            if (ch != L'\\' || escape_sequence[escape_sequence_length-1] != 0x1b)
+            if ((ch != L'\\' || escape_sequence[escape_sequence_length-1] != 0x1b) && ch != 0x07)
             {
                 add_escape_char(ch);
                 return WEOF;

--- a/tests/tests.bash
+++ b/tests/tests.bash
@@ -91,6 +91,8 @@ h3 "Other Overstrikes"
 t 'are discarded' -in 'X\bY' -out 'Y'
 
 h2 "Shell Integration"
+t 'ignores hyperlinks' -in 'editor: \e]8;;https://kakoune.org/\e\\kakoune\e]8;;\e\\' -out 'editor: kakoune'
+t 'ignores hyperlinks terminated by BEL' -in 'editor: \e]8;;https://kakoune.org/\akakoune\e]8;;\a' -out 'editor: kakoune'
 t 'ignores shell integration esapes' -in 'hello\e]133;A\e\\world' -out 'helloworld'
 
 h2 "Common Private Modes"


### PR DESCRIPTION
This is non-standard and introduced by Xterm, but some programs still use this.
Notably it appears in gcc's output.
